### PR TITLE
Fix TypeError in switch.py: async_schedule_update_ha_state must not be awaited

### DIFF
--- a/custom_components/hisense_ac_plugin/switch.py
+++ b/custom_components/hisense_ac_plugin/switch.py
@@ -471,4 +471,4 @@ class HisenseSwitch(CoordinatorEntity, SwitchEntity):
             )
         else:
             # 正常更新状态
-            await self.async_schedule_update_ha_state(True)
+            self.async_schedule_update_ha_state(True) #this is not to be awaited, generates a warning. Bug 2 in issue 28.


### PR DESCRIPTION
## Summary

Fixes #14, #16, and Bug 2 of #28 — the same one-line defect reported three times:

```
TypeError: object NoneType can't be used in 'await' expression
  custom_components/hisense_ac_plugin/switch.py:474
```

`async_schedule_update_ha_state()` is a callback that returns `None`; awaiting it raises on every scheduled update.

## Credit

This is @bsantelicesm's fix, cherry-picked with authorship preserved from their fork (see their comment in #28 — the fixes were sitting there since June without a PR). I'm just upstreaming it so everyone gets it via HACS.

Runs live on my 7-AC ConnectLife household.

🤖 Upstreamed with [Claude Code](https://claude.com/claude-code)